### PR TITLE
Fix compilation error on Android with react-native >= 0.47

### DIFF
--- a/android/src/main/java/net/jodybrewster/linkedinlogin/RNLinkedinLoginPackage.java
+++ b/android/src/main/java/net/jodybrewster/linkedinlogin/RNLinkedinLoginPackage.java
@@ -26,7 +26,6 @@ public class RNLinkedinLoginPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules was removed in React Native 0.47.0. See:
https://github.com/facebook/react-native/issues/15232